### PR TITLE
fix tkinter import in python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,12 @@ The basics for now. More details to be added here.
 
 Create a parent frame and then add the table to it:
 ```
-from tkinter import *
+try:
+	# python 3
+	from tkinter import *
+except ImportError:
+	# python 2
+	from Tkinter import *
 from pandastable import Table
 #assuming parent is the frame in which you want to place the table
 pt = Table(parent)

--- a/pandastable/core.py
+++ b/pandastable/core.py
@@ -24,13 +24,14 @@ try:
     import tkinter as tk
     from tkinter import ttk
     from tkinter import filedialog, messagebox, simpledialog, colorchooser
+    from tkinter import font
 except:
     import Tkinter as tk
     import ttk
     import tkFileDialog as filedialog
     import tkSimpleDialog as simpledialog
     import tkMessageBox as messagebox
-from tkinter import font
+    from tkFont import Font as font
 import os
 import string
 import platform

--- a/pandastable/plugins/example.py
+++ b/pandastable/plugins/example.py
@@ -20,12 +20,14 @@
 """
 
 from __future__ import absolute_import, division, print_function
-from tkinter import *
-import tkinter
 try:
     from tkinter.ttk import *
+    import tkinter as tk
+    from tkinter import *
 except:
     from ttk import *
+    import Tkinter as tk
+    from Tkinter import *
 from pandastable.plugin import Plugin
 
 class ExamplePlugin(Plugin):


### PR DESCRIPTION
Put tkinter import into the try clause for python 2.7 compatibility in
core.py and plugins/example.py. Also change the README to reflect this
subtle compatibility issue.

Suggestion: may be a better approach to import any packages with
potential compatibility issue (e.g. tkinter) in the package's
__init__.py, then let modules import it from __init__? It will be
cleaner and easier to maintain.